### PR TITLE
Feature/be encoding not being used bug

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 homepage: "https://www.channeladvisor.com/"
 documentation: "https://github.com/channeladvisor/channeladvisor-wtb-gtm-template/blob/master/README.md"
 versions:
-  - sha: bacc91ef43a40f8b8410610d305033642b09bcdf
+  - sha: d19fb38c9c7fb1cbe294af58ba34a47507a08853
     changeNotes: Initial release.

--- a/template.tpl
+++ b/template.tpl
@@ -150,7 +150,7 @@ switch(data.EventAction)
           const sendPixel = require('sendPixel'); //sends a get request
           const encodeUriComponent = require('encodeUriComponent');
          
-          var url = 'https://strack.where-to-buy.co/api/v1/gtm/recordSale/' + requestInformation + "&s.at="+accessToken;
+          var url = 'https://strack.where-to-buy.co/api/v1/gtm/recordSale/' + encodeUriComponent(requestInformation + "&s.at="+accessToken);
           log("Sending GET request to - " + url); 
           sendPixel(url);
     


### PR DESCRIPTION
The comment posted on our repo was that we need to use EncodeUrlComponent for the queryparams when creating the url.
The API was referenced in the template but not used at all. I changed the template so that we now use the Encode API when generating the url for all the query params part of the request as suggested by the guy at Google.